### PR TITLE
Escape username/password configuration values

### DIFF
--- a/gasher
+++ b/gasher
@@ -141,6 +141,11 @@ if [ ! -f "$configPath/config" ]; then
     read -sp "Please enter your GNU Social password: " password
     read -p "Post music to a group? You need to subscribe to the group for this to work: " -e -i listening musicGroup
     echo
+
+	# Escape config values
+	userName=$(echo "$userName" | sed -e "s/['\"\$\!]/\\\&/g")
+	password=$(echo "$password" | sed -e "s/['\"\$\!]/\\\&/g")
+
     echo -e "userName=${userName}\npassword=${password}\nuserNode=${userNode}" > "$configPath/config"
     if [ -n "$musicGroup" ] ; then
         echo "musicGroup=${musicGroup}" >> "$configPath/config"


### PR DESCRIPTION
I've added an extra two sed commands that escape the username and password values (it's possible that only the password needs escaping) so that special characters, like single & double quotes, the dollar sign, and exclamation mark don't get interpreted by bash.

_Apparently_ I'm the only one that uses crazy characters in my passwords!
