### PR TITLE
Load bash with /usr/bin/env

### DIFF
--- a/gasher
+++ b/gasher
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 clientName="${0##*/}"
 clientName="${clientName^}"


### PR DESCRIPTION
On Mac OS X, the default system Bash (v3.2.51) does not work with Gasher. (the build in `read` does not support the `-i` option.) This is a separate issue which I didn't try to fix here. Instead, I worked around it by installing an updated Bash (4.3.46) from the Homebrew package manager. To get Gasher to use this Bash, I had to use the `env` command.
